### PR TITLE
Use Python 3.7 for tox envs that don't start with `py`

### DIFF
--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -33,6 +33,9 @@ jobs:
           ${{ if or(eq(env, 'py38'), startsWith(env, 'py38-')) }}:
             py: '3.7'
             ispy38: true
+          # Use Python 3.7 by default for toxenvs that don't start with 'py'
+          ${{ if not(startsWith(env, 'py')) }}:
+            py: '3.7'
 
   pool:
     ${{ if eq(parameters.os, 'linux') }}:


### PR DESCRIPTION
Thanks for this project! Made the transition from Travis a breeze.

My fork has a number of modifications that are specific to my OSS projects, but I figured I'd upstream some of the ones that are more generally useful. Take em or leave em; I won't feel bad if you just close these.

This one is useful when you have tox envs that don't start with `py`, e.g. `lint`, `docs`.