### PR TITLE
Rename osx to macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This job checks out a go project, runs `go get` and then `go test`
 #### parameters
 
 - `go_versions`: list of go versions to test against
-- `os`: choices (`linux`, `windows`, `osx`)
+- `os`: choices (`linux`, `windows`, `macos`)
 - `tests`: what to `go test ...`, default `./...`
 - `pre_test`: `steps` to run before running `tox`, such as installing tools,
   etc.  default: `[]`

--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -39,7 +39,7 @@ jobs:
       vmImage: ubuntu-16.04
     ${{ if eq(parameters.os, 'windows') }}:
       vmImage: vs2017-win2016
-    ${{ if eq(parameters.os, 'osx') }}:
+    ${{ if eq(parameters.os, 'macos') }}:
       vmImage: macOS-10.13
 
   variables:


### PR DESCRIPTION
https://en.wikipedia.org/wiki/MacOS

This is technically a breaking change. Let me know if I should make it backwards-compatible.