### PR TITLE
Revert "Merge pull request #31 from asottile/add_wheel"

### DIFF
--- a/job--python-tox.yml
+++ b/job--python-tox.yml
@@ -71,7 +71,7 @@ jobs:
 
   - ${{ parameters.pre_test }}
 
-  - script: python -m pip install --upgrade tox setuptools virtualenv wheel
+  - script: python -m pip install --upgrade tox setuptools virtualenv
     displayName: install tox
   - script: tox
     displayName: run tox


### PR DESCRIPTION
This reverts commit dced81c9b79e7a4f0dc9ef6c4f4a0219e60aa3ea, reversing
changes made to f8721c757e218487ca0bb38af0201b2a04e9ed52.

I can't think of a reason this should be there so why not remove it -- maybe next time I'll understand and add it back with more docs